### PR TITLE
minor edits to add/edit definitions

### DIFF
--- a/src/ontology/aism-edit.owl
+++ b/src/ontology/aism-edit.owl
@@ -25,7 +25,7 @@ Annotation(dce:description "The ontology for the Anatomy of the Insect SkeletoMu
 Annotation(dce:title "Ontology for the Anatomy of the Insect SkeletoMuscular system"@en)
 Annotation(dcterms:license <https://creativecommons.org/licenses/by/4.0/>)
 
-Declaration(Class(<http://purl.obolibrary.org/obo/AISM_00000000>))
+Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0000000>))
 Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0000002>))
 Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0000003>))
 Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0000004>))
@@ -218,8 +218,6 @@ Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0000532>))
 Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0000533>))
 Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0000534>))
 Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0000535>))
-Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0000536>))
-Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0000537>))
 Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0002002>))
 Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0002003>))
 Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0002004>))
@@ -533,6 +531,9 @@ Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0004230>))
 Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0004231>))
 Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0004232>))
 Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0004233>))
+Declaration(Class(<http://purl.obolibrary.org/obo/AISM_0004237>))
+Declaration(Class(<http://purl.obolibrary.org/obo/BSPO_0000377>))
+Declaration(Class(<http://purl.obolibrary.org/obo/BSPO_0000378>))
 Declaration(Class(<http://purl.obolibrary.org/obo/BSPO_0000671>))
 Declaration(Class(<http://purl.obolibrary.org/obo/BSPO_0000672>))
 Declaration(Class(<http://purl.obolibrary.org/obo/BSPO_0000677>))
@@ -648,17 +649,18 @@ SubObjectPropertyOf(<http://purl.obolibrary.org/obo/AISM_0000079> <http://purl.o
 
 # Object Property: <http://purl.obolibrary.org/obo/AISM_0000519> (encircles via conjunctiva)
 
-AnnotationAssertion(Annotation(dce:contributor "starasov") Annotation(<http://www.geneontology.org/formats/oboInOwl#creation_date> "2021-05-31") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/AISM_0000519> "sclerite A encircles_via_conjunctiva sclerite B iff A encircled_by conjuntiva X that encircles B")
+AnnotationAssertion(Annotation(dce:contributor "starasov") Annotation(<http://www.geneontology.org/formats/oboInOwl#creation_date> "2021-05-31") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/AISM_0000519> "sclerite A encircles_via_conjunctiva sclerite B if A is encircled_via_conjuntiva X that encircles B"@en)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AISM_0000519> "encircles via conjunctiva"@en)
-SubObjectPropertyOf(<http://purl.obolibrary.org/obo/AISM_0000519> <http://purl.obolibrary.org/obo/RO_0002323>)
+SubObjectPropertyOf(<http://purl.obolibrary.org/obo/AISM_0000519> <http://purl.obolibrary.org/obo/AISM_0000078>)
 InverseObjectProperties(<http://purl.obolibrary.org/obo/AISM_0000519> <http://purl.obolibrary.org/obo/AISM_0000538>)
 ObjectPropertyDomain(<http://purl.obolibrary.org/obo/AISM_0000519> <http://purl.obolibrary.org/obo/AISM_0000003>)
 ObjectPropertyRange(<http://purl.obolibrary.org/obo/AISM_0000519> <http://purl.obolibrary.org/obo/AISM_0000003>)
 
 # Object Property: <http://purl.obolibrary.org/obo/AISM_0000538> (encircled via conjunctiva)
 
+AnnotationAssertion(Annotation(dce:contributor "jgiron https://orcid.org/0000-0002-0851-6883") Annotation(<http://www.geneontology.org/formats/oboInOwl#creation_date> "2021-06-14") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/AISM_0000538> "sclerite B is encircled_via_conjunctiva if sclerite A encircles_via_conjuntiva X sclerite B"@en)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AISM_0000538> "encircled via conjunctiva"@en)
-SubObjectPropertyOf(<http://purl.obolibrary.org/obo/AISM_0000538> <http://purl.obolibrary.org/obo/RO_0002323>)
+SubObjectPropertyOf(<http://purl.obolibrary.org/obo/AISM_0000538> <http://purl.obolibrary.org/obo/AISM_0000079>)
 ObjectPropertyDomain(<http://purl.obolibrary.org/obo/AISM_0000538> <http://purl.obolibrary.org/obo/AISM_0000003>)
 ObjectPropertyRange(<http://purl.obolibrary.org/obo/AISM_0000538> <http://purl.obolibrary.org/obo/AISM_0000003>)
 
@@ -672,13 +674,13 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/RO_0002372> "has 
 #   Classes
 ############################
 
-# Class: <http://purl.obolibrary.org/obo/AISM_00000000> (cuticular internal depression)
+# Class: <http://purl.obolibrary.org/obo/AISM_0000000> (cuticular internal depression)
 
-AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#created_by> "2021 05 19") Annotation(<http://www.geneontology.org/formats/oboInOwl#created_by> "jgiron") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/AISM_00000000> "The projection of the inner surface of the cuticle."@en)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AISM_00000000> "cuticular internal depression"@en)
-SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_00000000> <http://purl.obolibrary.org/obo/AISM_0000174>)
-SubClassOf(<http://purl.obolibrary.org/obo/AISM_00000000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/AISM_0000537>))
-SubClassOf(Annotation(dce:contributor "jgiron") <http://purl.obolibrary.org/obo/AISM_00000000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000053> <http://purl.obolibrary.org/obo/PATO_0001857>))
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#created_by> "2021-05-19") Annotation(<http://www.geneontology.org/formats/oboInOwl#created_by> "jgiron") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/AISM_0000000> "The projection of the inner surface of the cuticle."@en)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AISM_0000000> "cuticular internal depression"@en)
+SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000000> <http://purl.obolibrary.org/obo/AISM_0000174>)
+SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/BSPO_0000377>))
+SubClassOf(Annotation(dce:contributor "jgiron") <http://purl.obolibrary.org/obo/AISM_0000000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000053> <http://purl.obolibrary.org/obo/PATO_0001857>))
 
 # Class: <http://purl.obolibrary.org/obo/AISM_0000002> (insect articulation)
 
@@ -723,7 +725,7 @@ AnnotationAssertion(Annotation(dce:contributor "imiko") Annotation(<http://www.g
 AnnotationAssertion(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/IAO_0000232> <http://purl.obolibrary.org/obo/AISM_0000005> "External cuticular depression. The surface of the cuticle in insects is the entire surface of an organism, and it is composed of flat, concave and convex regions. Concavities sometimes correspons with invaginations of the cuticle and the underlaying sinlge layer epidermis, somtimes correspond to a decreased cuticular thickness.")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AISM_0000005> "cuticular depression"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000005> <http://purl.obolibrary.org/obo/AISM_0000174>)
-SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000005> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/AISM_0000536>))
+SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000005> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/BSPO_0000378>))
 SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000005> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000053> <http://purl.obolibrary.org/obo/PATO_0001857>))
 
 # Class: <http://purl.obolibrary.org/obo/AISM_0000006> (cuticular invagination)
@@ -731,7 +733,7 @@ SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/A
 AnnotationAssertion(Annotation(dce:contributor "imiko") Annotation(<http://www.geneontology.org/formats/oboInOwl#creation_date> "2020-10-27") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/AISM_0000006> "The region of cuticle that corresponds with an invagination of the single layer epidermis (epidermal fold). The cuticular invagination sometimes corresponds to a cuticular depression (concavity on the surface of the cuticle)."@en)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AISM_0000006> "cuticular invagination"@en)
 SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000006> <http://purl.obolibrary.org/obo/AISM_0000174>)
-SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002008> <http://purl.obolibrary.org/obo/AISM_00000000>))
+SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002008> <http://purl.obolibrary.org/obo/AISM_0000000>))
 SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000006> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002008> <http://purl.obolibrary.org/obo/AISM_0000005>))
 
 # Class: <http://purl.obolibrary.org/obo/AISM_0000007> (elastic cuticle)
@@ -747,7 +749,7 @@ AnnotationAssertion(Annotation(dce:contributor "imiko") Annotation(<http://www.g
 AnnotationAssertion(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/IAO_0000232> <http://purl.obolibrary.org/obo/AISM_0000008> "The surface of the cuticle in insects is the entire surface of an organism, and it is composed of flat, concave and convex regions. Convexities sometimes correspons with evaginations of the cuticle and the underlaying sinlge layer epidermis and sometimes correspond to an increased cuticular thickness.\"")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AISM_0000008> "cuticular protrusion"@en)
 SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000008> <http://purl.obolibrary.org/obo/AISM_0000174>)
-SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000008> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/AISM_0000536>))
+SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000008> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/BSPO_0000378>))
 SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000008> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000053> <http://purl.obolibrary.org/obo/PATO_0001355>))
 
 # Class: <http://purl.obolibrary.org/obo/AISM_0000013> (evaginated)
@@ -2206,7 +2208,7 @@ https://doi.org/10.1515/9783110264043
 
 \"Ridge: cuticular strengthening ridge.\"
 \"They are not lines of fusion or molting lines.\"(p. 12)"@en) rdfs:label <http://purl.obolibrary.org/obo/AISM_0000158> "ridge"@en)
-SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000158> <http://purl.obolibrary.org/obo/AISM_00000000>)
+SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000158> <http://purl.obolibrary.org/obo/AISM_0000000>)
 SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000158> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/AISM_0000003>))
 SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000158> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000053> <http://purl.obolibrary.org/obo/PATO_0001154>))
 
@@ -2411,7 +2413,7 @@ https://doi.org/10.1515/9783110264043
 https://doi.org/10.1111/j.1096-3642.2001.tb02239.x 
 
 \"tendon is used herein to designate sclerotized internal cuticular projections\""@en) rdfs:label <http://purl.obolibrary.org/obo/AISM_0000188> "apodeme"@en)
-SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000188> <http://purl.obolibrary.org/obo/AISM_00000000>)
+SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000188> <http://purl.obolibrary.org/obo/AISM_0000000>)
 SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000188> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/AISM_0000003>))
 SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/AISM_0000188> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000053> <http://purl.obolibrary.org/obo/PATO_0001873>))
 
@@ -2658,18 +2660,6 @@ SubClassOf(Annotation(dce:contributor "imiko") <http://purl.obolibrary.org/obo/A
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AISM_0000535> "conjunctival appendage"@en)
 SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000535> <http://purl.obolibrary.org/obo/AISM_0000029>)
 SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000535> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/AISM_0000004>))
-
-# Class: <http://purl.obolibrary.org/obo/AISM_0000536> (external side)
-
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AISM_0000536> "external side"@en)
-SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000536> <http://purl.obolibrary.org/obo/BSPO_0000054>)
-SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000536> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BSPO_0000113> <http://purl.obolibrary.org/obo/AISM_0000537>))
-
-# Class: <http://purl.obolibrary.org/obo/AISM_0000537> (internal side)
-
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AISM_0000537> "internal side"@en)
-SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000537> <http://purl.obolibrary.org/obo/BSPO_0000054>)
-SubClassOf(<http://purl.obolibrary.org/obo/AISM_0000537> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BSPO_0000113> <http://purl.obolibrary.org/obo/AISM_0000536>))
 
 # Class: <http://purl.obolibrary.org/obo/AISM_0002002> (anterior tentorio-scapal muscle)
 
@@ -6377,6 +6367,23 @@ SubClassOf(Annotation(dce:contributor "jgiron") <http://purl.obolibrary.org/obo/
 SubClassOf(Annotation(dce:contributor "jgiron") <http://purl.obolibrary.org/obo/AISM_0004233> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000050> <http://purl.obolibrary.org/obo/AISM_0004126>))
 SubClassOf(Annotation(rdfs:comment "jgiron") <http://purl.obolibrary.org/obo/AISM_0004233> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002150> <http://purl.obolibrary.org/obo/AISM_0000064>))
 SubClassOf(Annotation(dce:contributor "jgiron") <http://purl.obolibrary.org/obo/AISM_0004233> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002150> <http://purl.obolibrary.org/obo/AISM_0000121>))
+
+# Class: <http://purl.obolibrary.org/obo/AISM_0004237> (lobe)
+
+AnnotationAssertion(Annotation(dce:contributor "jgiron https://orcid.org/0000-0002-0851-6883") Annotation(<http://www.geneontology.org/formats/oboInOwl#creation_date> "2021-06-14") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/AISM_0004237> "The cuticular evagination of the cuticle that is largely membranous."@en)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AISM_0004237> "lobe"@en)
+SubClassOf(Annotation(dce:contributor "jgiron https://orcid.org/0000-0002-0851-6883") Annotation(<http://www.geneontology.org/formats/oboInOwl#creation_date> "2021-06-14") <http://purl.obolibrary.org/obo/AISM_0004237> <http://purl.obolibrary.org/obo/AISM_0000027>)
+SubClassOf(Annotation(dce:contributor "jgiron https://orcid.org/0000-0002-0851-6883") Annotation(<http://www.geneontology.org/formats/oboInOwl#creation_date> "2021-06-14") <http://purl.obolibrary.org/obo/AISM_0004237> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/AISM_0000004>))
+
+# Class: <http://purl.obolibrary.org/obo/BSPO_0000377> (internal side)
+
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/BSPO_0000377> "internal side"@en)
+SubClassOf(<http://purl.obolibrary.org/obo/BSPO_0000377> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BSPO_0000113> <http://purl.obolibrary.org/obo/BSPO_0000378>))
+
+# Class: <http://purl.obolibrary.org/obo/BSPO_0000378> (external side)
+
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/BSPO_0000378> "external side"@en)
+SubClassOf(<http://purl.obolibrary.org/obo/BSPO_0000378> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BSPO_0000113> <http://purl.obolibrary.org/obo/BSPO_0000377>))
 
 # Class: <http://purl.obolibrary.org/obo/OBI_0002648> (individual organism specimen)
 


### PR DESCRIPTION
Minor edits including definitions for 'enccircled via conjunctiva', fix AISM_0000000; added 'lobe' (including definitions and annotations).