### PR TITLE
Illegal OWL 2 DL: encircles via conjunctiva

### DIFF
--- a/src/ontology/aism-edit.owl
+++ b/src/ontology/aism-edit.owl
@@ -6836,6 +6836,4 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UBERON_0004175> "
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UBERON_0014895> "somatic muscle"@en)
 
 
-SubObjectPropertyOf(ObjectPropertyChain(<http://purl.obolibrary.org/obo/AISM_0000078> <http://purl.obolibrary.org/obo/AISM_0000078>) <http://purl.obolibrary.org/obo/AISM_0000519>)
-SubObjectPropertyOf(ObjectPropertyChain(<http://purl.obolibrary.org/obo/AISM_0000079> <http://purl.obolibrary.org/obo/AISM_0000079>) <http://purl.obolibrary.org/obo/AISM_0000538>)
 )


### PR DESCRIPTION
This fixes the OWL 2 DL profile violation you were experiencing.

The problem is in essence that encircles, a transitive relation, was used in a property chain of a child relation. This is not permitted and leads to incomplete reasoning. I don't know how to do this better, but you will have to revise your modelling of `encircles by conjunctiva`. 